### PR TITLE
Remove "Promoted Quest" from Active Now

### DIFF
--- a/DubyasCleanupOfDiscord.css
+++ b/DubyasCleanupOfDiscord.css
@@ -111,3 +111,8 @@ div[class*="shakeReaction_"]
 {
     animation: none !important;
 }
+
+/* Remove "Promoted" Quest in Active Now sidebar */
+div[class^="itemCard__"] > div > div[class^="body__"]:has(span[class^="promotedTagBackground__"]) {
+    display: none;
+}


### PR DESCRIPTION
The `div[class^=itemCard__]` object for Active Now has a `<header>` child to display the actual user, and then can have other objects to act as popout cards, like the promotion:

<img width="1198" height="568" alt="image" src="https://github.com/user-attachments/assets/4f079530-41dc-4ea7-bc0f-90d7cf3af047" />

I did a quite narrow filter, you might be tempted to solve this with something like `div[class^="itemCard__"] > div > div[class^="body__"]:not(:first-child)` as a more robust solution, but that would actually remove rich presence popouts as well:

<img width="1159" height="369" alt="image" src="https://github.com/user-attachments/assets/3124aaf7-10e6-4740-ae01-6fe5af0c6400" />

You can theoretically expand out this rule and nest whatever you need to do in the future.
